### PR TITLE
Fix `Learn Go with Tests` Link Typo

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -14,7 +14,7 @@
 - go by example: handy and useful for learning a special concept [+](https://dlintw.github.io/gobyexample/public/#by-sequence)
 - effective go: documentation page about writing better go code [+](https://golang.org/doc/effective_go)
 - little go book [+](https://www.openmymind.net/The-Little-Go-Book/)
-- learn go with tests [+](https://www.openmymind.net/The-Little-Go-Book/)
+- learn go with tests [+](https://quii.gitbook.io/learn-go-with-tests/)
 
 ### Specific posts
 


### PR DESCRIPTION
The links to 'Little Go Book' and 'Learn Go with Tests' were identical. Here's a typo fix! :D